### PR TITLE
Update iond.cpp

### DIFF
--- a/src/iond.cpp
+++ b/src/iond.cpp
@@ -50,6 +50,7 @@ bool AppInit(int argc, char* argv[])
         {
             fprintf(stderr, "Error: Specified directory does not exist\n");
             Shutdown();
+	    return false;
         }
         ReadConfigFile(mapArgs, mapMultiArgs);
 


### PR DESCRIPTION
When using the -datadir directive and an invalid directory/folder is provided then the error message "Error: Specified directory does not exist" is output however the process continues using the default folder (an undesired effect) when it should in fact terminate at this point.