### PR TITLE
Disable minting v2 xION

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -901,6 +901,10 @@ bool CheckZerocoinMint(const uint256& txHash, const CTxOut& txout, CValidationSt
 
 bool ContextualCheckZerocoinMint(const CTransaction& tx, const PublicCoin& coin, const CBlockIndex* pindex)
 {
+    if (pindex->nHeight >= Params().Zerocoin_Block_V2_Start()) {
+        return error("%s: Minting zerocoins is disabled.", __func__);
+    }
+
     if (pindex->nHeight >= Params().Zerocoin_Block_V2_Start() && Params().NetworkID() != CBaseChainParams::TESTNET) {
         //See if this coin has already been added to the blockchain
         uint256 txid;

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -176,6 +176,11 @@ void PrivacyDialog::on_pushButtonMintxION_clicked()
         return;
     }
 
+    QMessageBox::information(this, tr("Mint Zerocoin"),
+                                tr("Minting xION is currently disabled."), QMessageBox::Ok,
+                                QMessageBox::Ok);
+    return;
+
     // Reset message text
     ui->TEMintStatus->setPlainText(tr("Mint Status: Okay"));
 
@@ -834,15 +839,15 @@ void PrivacyDialog::updateSPORK16Status()
     if (fMaintenanceMode && fButtonsEnabled) {
         // Mint xION
         ui->pushButtonMintxION->setEnabled(false);
-        ui->pushButtonMintxION->setToolTip(tr("xION is currently disabled due to maintenance."));
+        ui->pushButtonMintxION->setToolTip(tr("Minting xION is currently disabled."));
 
         // Spend xION
         ui->pushButtonSpendxION->setEnabled(false);
         ui->pushButtonSpendxION->setToolTip(tr("xION is currently disabled due to maintenance."));
     } else if (!fMaintenanceMode && !fButtonsEnabled) {
         // Mint xION
-        ui->pushButtonMintxION->setEnabled(true);
-        ui->pushButtonMintxION->setToolTip(tr("PrivacyDialog", "Enter an amount of ION to convert to xION", 0));
+        ui->pushButtonMintxION->setEnabled(false);
+        ui->pushButtonMintxION->setToolTip(tr("Minting xION is currently disabled."));
 
         // Spend xION
         ui->pushButtonSpendxION->setEnabled(true);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2812,7 +2812,7 @@ UniValue mintzerocoin(const UniValue& params, bool fHelp)
     int64_t nTime = GetTimeMillis();
     if(GetAdjustedTime() > GetSporkValue(SPORK_9_ZEROCOIN_MAINTENANCE_MODE))
         throw JSONRPCError(RPC_WALLET_ERROR, "xION is currently disabled due to maintenance.");
-    
+
     throw JSONRPCError(RPC_WALLET_ERROR, "Minting xION is currently disabled.");
 
     EnsureWalletIsUnlocked(true);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2812,6 +2812,8 @@ UniValue mintzerocoin(const UniValue& params, bool fHelp)
     int64_t nTime = GetTimeMillis();
     if(GetAdjustedTime() > GetSporkValue(SPORK_9_ZEROCOIN_MAINTENANCE_MODE))
         throw JSONRPCError(RPC_WALLET_ERROR, "xION is currently disabled due to maintenance.");
+    
+    throw JSONRPCError(RPC_WALLET_ERROR, "Minting xION is currently disabled.");
 
     EnsureWalletIsUnlocked(true);
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2130,6 +2130,9 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInp
 
     //xION
     if (GetBoolArg("-xionstake", true) && chainActive.Height() > Params().Zerocoin_Block_V2_Start() && !IsSporkActive(SPORK_9_ZEROCOIN_MAINTENANCE_MODE)) {
+
+        return true;
+
         //Only update xION set once per update interval
         bool fUpdate = false;
         static int64_t nTimeLastUpdate = 0;
@@ -4143,6 +4146,8 @@ void CWallet::AutoZeromint()
 {
     // Don't bother Autominting if Zerocoin Protocol isn't active
     if (GetAdjustedTime() > GetSporkValue(SPORK_9_ZEROCOIN_MAINTENANCE_MODE)) return;
+
+    return;
 
     // Wait until blockchain + masternodes are fully synced and wallet is unlocked.
     if (!masternodeSync.IsSynced() || IsLocked()){


### PR DESCRIPTION
Disable minting of v2 xION after maintenance mode has ended - through the GUI and in the consensus rules. 
Full functionality is still present.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/cevap%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/24996551%3Fv%3D4%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cevap/ion/pull/97%23issuecomment-449412926%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-12-21T15%3A11%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/24996551%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cevap%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/cevap/ion/pull/97%23issuecomment-449412926%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/cevap'><img src='https://avatars3.githubusercontent.com/u/24996551?v=4' width=34 height=34></a>

<a href='https://www.codereviewhub.com/cevap/ion/pull/97?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cevap/ion/pull/97?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/cevap/ion/pull/97'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>