### PR TITLE
Update spork key valid time

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -171,7 +171,7 @@ public:
         nInvalidAmountFiltered = 0*COIN;            //Amount of invalid coins filtered through exchanges, that should be considered valid
         nBlockZerocoinV2 = 966630;                  //!> The block that zerocoin v2 becomes active - roughly Tuesday, Janury 8, 2019 10:24:00 AM GMT
         nEnforceNewSporkKey = 1546214401;           //!> Sporks signed after Thursday, GMT: Monday, 31. December 2018 00:00:01 must use the new spork key
-        nRejectOldSporkKey = 1547121601;            //!> Reject old spork key after GMT: Sunday, January 6, 2019 12:00:01 AM
+        nRejectOldSporkKey = 1546732801;            //!> Reject old spork key after Wednesday, GMT: Sunday, January 6, 2019 12:00:01 AM
 
         nMidasStartHeight = 176500;                 // MIDAS startheight, first big attack
         nMidasStartTime = 1497541280;               // Time when MIDAS started and old algorithm stopped

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -171,7 +171,7 @@ public:
         nInvalidAmountFiltered = 0*COIN;            //Amount of invalid coins filtered through exchanges, that should be considered valid
         nBlockZerocoinV2 = 966630;                  //!> The block that zerocoin v2 becomes active - roughly Tuesday, Janury 8, 2019 10:24:00 AM GMT
         nEnforceNewSporkKey = 1546214401;           //!> Sporks signed after Thursday, GMT: Monday, 31. December 2018 00:00:01 must use the new spork key
-        nRejectOldSporkKey = 1546732801;            //!> Reject old spork key after Wednesday, GMT: Sunday, 6. January 2019 00:00:01
+        nRejectOldSporkKey = 1547121601;            //!> Reject old spork key after GMT: Sunday, January 6, 2019 12:00:01 AM
 
         nMidasStartHeight = 176500;                 // MIDAS startheight, first big attack
         nMidasStartTime = 1497541280;               // Time when MIDAS started and old algorithm stopped
@@ -300,8 +300,8 @@ public:
         nBlockEnforceInvalidUTXO = 10000000; //Start enforcing the invalid UTXO's
         nInvalidAmountFiltered = 0; //Amount of invalid coins filtered through exchanges, that should be considered valid
         nBlockZerocoinV2 = 474100; //!> The block that zerocoin v2 becomes active
-        nEnforceNewSporkKey = 1546214401; //!> Sporks signed after Thursday, GMT: Monday, 31. December 2018 00:00:01 must use the new spork key
-        nRejectOldSporkKey = 1546732801; //!> Reject old spork key after Wednesday, GMT: Sunday, 6. January 2019 00:00:01
+        nEnforceNewSporkKey = 1545361200; //!> Sporks signed after 12/21/2018 @ 3:00am (UTC) must use the new spork key
+        nRejectOldSporkKey = 1545620400; //!> Reject old spork key after 12/24/2018 @ 3:00am (UTC)
 
         nMidasStartHeight = 75000;
         nMidasStartTime = 1497209344;


### PR DESCRIPTION
Clients lost sync due to signature verification issues on testnet using the old settings.

Rejecting the old key after the fork reduces the chance of old clients forking off before the actual fork
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cevap/ion/pull/101%23issuecomment-449458099%22%2C%20%22https%3A//github.com/cevap/ion/pull/101%23issuecomment-449458315%22%2C%20%22https%3A//github.com/cevap/ion/pull/101%23issuecomment-449458782%22%2C%20%22https%3A//github.com/cevap/ion/pull/101%23issuecomment-449459333%22%2C%20%22https%3A//github.com/cevap/ion/pull/101%23issuecomment-449460670%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cevap/ion/pull/101%23issuecomment-449458099%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22For%20main%20net%3A%5Cr%5Cn-%20why%20do%20you%20change%20it%20to%20GMT%3A%20Thursday%2C%2010.%20January%202019%2012%3A00%3A01%3F%20That%20should%20not%20be%20the%20case%2C%20it%20should%20be%20%601546732801%60%20like%20it%20was.%22%2C%20%22created_at%22%3A%20%222018-12-21T18%3A05%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/24996551%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cevap%22%7D%7D%2C%20%7B%22body%22%3A%20%22we%20dont%20want%20old%20clients%20to%20be%20accepted%20after%3A%201546732801%22%2C%20%22created_at%22%3A%20%222018-12-21T18%3A06%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/24996551%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cevap%22%7D%7D%2C%20%7B%22body%22%3A%20%22for%20testnet%20we%20can%20change%2C%20you%20just%20need%20bootstrap%22%2C%20%22created_at%22%3A%20%222018-12-21T18%3A08%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/24996551%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cevap%22%7D%7D%2C%20%7B%22body%22%3A%20%22and%20on%20testnet%20it%20seems%20to%20work%20properly%2C%20as%20old%20clients%20are%20banned%20which%20is%20actually%20what%20we%20want%20on%20testnet%20too.%20Basicly%2C%20using%20new%20client%20will%20work%2C%20why%20would%20you%20like%20to%20use%20old%20client%20on%20testnet%20now%2C%20for%20testing%20it%20we%20can%20do%20so%2C%20but%20this%20change%20will%20make%20previous%20builds%20invalid.%22%2C%20%22created_at%22%3A%20%222018-12-21T18%3A10%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/24996551%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cevap%22%7D%7D%2C%20%7B%22body%22%3A%20%22-%20%5B%20%5D%20we%20should%20update%20dns%20seeds%20with%20active%20ip%27s%22%2C%20%22created_at%22%3A%20%222018-12-21T18%3A16%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/24996551%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cevap%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cevap/ion/pull/101#issuecomment-449458099'>General Comment</a></b>
- <a href='https://github.com/cevap'><img border=0 src='https://avatars3.githubusercontent.com/u/24996551?v=4' height=16 width=16></a> For main net:
- why do you change it to GMT: Thursday, 10. January 2019 12:00:01? That should not be the case, it should be `1546732801` like it was.
- <a href='https://github.com/cevap'><img border=0 src='https://avatars3.githubusercontent.com/u/24996551?v=4' height=16 width=16></a> we dont want old clients to be accepted after: 1546732801
- <a href='https://github.com/cevap'><img border=0 src='https://avatars3.githubusercontent.com/u/24996551?v=4' height=16 width=16></a> for testnet we can change, you just need bootstrap
- <a href='https://github.com/cevap'><img border=0 src='https://avatars3.githubusercontent.com/u/24996551?v=4' height=16 width=16></a> and on testnet it seems to work properly, as old clients are banned which is actually what we want on testnet too. Basicly, using new client will work, why would you like to use old client on testnet now, for testing it we can do so, but this change will make previous builds invalid.
- <a href='https://github.com/cevap'><img border=0 src='https://avatars3.githubusercontent.com/u/24996551?v=4' height=16 width=16></a> - [ ] we should update dns seeds with active ip's


<a href='https://www.codereviewhub.com/cevap/ion/pull/101?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cevap/ion/pull/101?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cevap/ion/pull/101'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>